### PR TITLE
general perfdata, embedded Perl Nagios, and juniper enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Original script: http://exchange.nagios.org/directory/Plugins/Hardware/Network-G
 
 Changes:
 
- # Add performance data output for Cisco switch temperatures
- # general: Enable use of Nagios ePN (embedded Perl Nagios)
- # juniper: Hardcoded global box thresholds for mem, temp, CPU
- # juniper: Field Replaceable Units (FRUs) monitoring
- # juniper: Alarms counts (Red, Yellow)
+ # Add performance data output for Cisco switch temperatures    
+ # general: Enable use of Nagios ePN (embedded Perl Nagios)    
+ # juniper: Hardcoded global box thresholds for mem, temp, CPU    
+ # juniper: Field Replaceable Units (FRUs) monitoring    
+ # juniper: Alarms counts (Red, Yellow)    
 
 
 check_usbtlight.pl

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Changes:
  #    - Added warning and critical checks (René Koch)
 
 
-
 check_snmp_environment.pl
 -------------------------
   
@@ -44,7 +43,11 @@ Original script: http://exchange.nagios.org/directory/Plugins/Hardware/Network-G
 
 Changes:
 
- # Add performance data output for Cisco switch temperatures    
+ # Add performance data output for Cisco switch temperatures
+ # general: Enable use of Nagios ePN (embedded Perl Nagios)
+ # juniper: Hardcoded global box thresholds for mem, temp, CPU
+ # juniper: Field Replaceable Units (FRUs) monitoring
+ # juniper: Alarms counts (Red, Yellow)
 
 
 check_usbtlight.pl


### PR DESCRIPTION
I sent these improvements to the original author, but they don't have a github.  I found your github and decided it was a good place to start merging changes in.

Enable use of Nagios ePN (embedded Perl Nagios).  Use 'our' instead of 'my' variables to keep Nagios happy.  Add -w and clean up perl warnings.

Global box thresholds for all Components and FRUs.  Thresholds are currently hardcoded in the script, based on our experience for what is "normal" and to reduce frequent alerts.  There are no perfect values, and I still see occasional alerts on CPU and load average, but I've found these values to be a good balance between over alerting and warning us that something bad is about to happen.

Juniper kernel memory         80%
Juniper temperature       62C
Juniper CPU utilization       95% (since disabled due to uselessness)
Juniper Interrupt utilization     50%
Juniper Buffer utilization    80%
Juniper Heap utilization      70%
Juniper CPU load averages:
    1-minute          5.0
    5-minute          4.0
    15-minute         3.0

Juniper Field Replaceable Units (FRUs) - there may be some overlap between the FRU MIB and the Component MIB, but I wanted to make sure I was covering everything in case there are differences.

Juniper Alarms (Red, Yellow).  Unfortunately, Juniper does not expose the actual alarm text via SNMP, so this is just a summary of how many Yellow and Red alarms there are.  Once you get an alarm, you have to SSH in to see what it is...
